### PR TITLE
Support to connect via SSH to data sources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -343,6 +343,14 @@
         "@types/through": "*"
       }
     },
+    "@types/ip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ip/-/ip-1.1.0.tgz",
+      "integrity": "sha512-dwNe8gOoF70VdL6WJBwVHtQmAX4RMd62M+mAB9HQFjG1/qiCLM/meRy95Pd14FYBbEDwCq7jgJs89cHpLBu4HQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/js-yaml": {
       "version": "3.11.4",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.11.4.tgz",
@@ -373,8 +381,7 @@
     "@types/node": {
       "version": "10.12.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
-      "dev": true
+      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
     },
     "@types/rx": {
       "version": "4.1.1",
@@ -1760,6 +1767,11 @@
       "resolved": "https://registry.npmjs.org/inversify/-/inversify-5.0.1.tgz",
       "integrity": "sha512-Ieh06s48WnEYGcqHepdsJUIJUXpwH5o5vodAX+DK2JA/gjy4EbEcQZxw+uFfzysmKjiLXGYwNG3qDZsKVMcINQ==",
       "dev": true
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
   "dependencies": {
     "@oclif/command": "^1.5.8",
     "@oclif/config": "^1.10.3",
+    "@types/ip": "^1.1.0",
     "aws-sdk": "^2.382.0",
     "chalk": "^2.4.1",
     "cli-ux": "^5.0.0",
     "inquirer": "^6.2.1",
+    "ip": "^1.1.5",
     "js-yaml": "^3.13.1",
     "lodash": ">=4.17.13",
     "tslib": "^1.9.3"

--- a/src/config/main-config.json
+++ b/src/config/main-config.json
@@ -95,7 +95,7 @@
       "test"
     ],
     "defaultEnvironment": "development",
-    "connections": [
+    "dataSources": [
       {
         "name": "api",
         "environments": {
@@ -106,12 +106,7 @@
             "password": "pg",
             "database": "kgalli",
             "engine": "postgresql",
-            "ssh": {
-              "proxyHost": "",
-              "proxyUser": "",
-              "sshKeyLocation": "",
-              "sshKeyPassword": ""
-            }
+            "readonly": false
           }
         }
       }

--- a/src/config/main-config.ts
+++ b/src/config/main-config.ts
@@ -11,7 +11,7 @@ interface MainConfig {
   dbTools: {
     environments: string[],
     defaultEnvironment: string
-    connections: Connection[]
+    dataSources: DataSource[]
   },
 }
 
@@ -25,22 +25,28 @@ interface Service {
   source: CodeSource
 }
 
-interface Connection {
+interface DataSource {
   name: string
   environments: {
-    [key: string]: ConnectionParams
+    [key: string]: DataSourceParams
   }
 }
 
-export default interface ConnectionParams {
+interface SshParams {
+  beforeShellCmd?: string
+  jumpHost: string
+  localPort: number
+}
+
+export default interface DataSourceParams {
   host: string
   port: number
   user: string
   password: string
-  database?: string
-  command?: string
+  database: string
   engine: DbEngine
-  ssh?: any
+  readonly: boolean
+  ssh?: SshParams
 }
 
 const enum DbEngine {
@@ -76,4 +82,4 @@ export interface EnvironmentVariable {
   [key: string]: string
 }
 
-export {MainConfig, CodeSource, Service, Connection}
+export {MainConfig, CodeSource, Service, DataSourceParams, DataSource}

--- a/src/wrapper/db-tools/db-tools-wrapper.ts
+++ b/src/wrapper/db-tools/db-tools-wrapper.ts
@@ -1,6 +1,7 @@
+import {address} from 'ip'
 import {isEmpty} from 'lodash'
 
-import {Connection} from '../../config/main-config'
+import {DataSource, DataSourceParams} from '../../config/main-config'
 
 import ConnectionParams from './connection-params'
 import DockerOptions from './docker-options'
@@ -10,109 +11,134 @@ import PostgreSql from './postgre-sql'
 
 export default class DbToolsWrapper {
   shellWrapper: any
-  connections: Connection[]
+  dataSources: DataSource[]
   dryRun: boolean
 
-  constructor(connections: Connection[], dryRun: boolean, shellWrapper: any) {
-    this.connections = connections
+  constructor(dataSources: DataSource[], dryRun: boolean, shellWrapper: any) {
+    this.dataSources = dataSources
     this.dryRun = dryRun
     this.shellWrapper = shellWrapper
   }
 
-  // tslint:disable-next-line no-unused
-  console(options: any, connectionName: string, environment: string) {
-    this.validate(connectionName)
-    const service = this.connectionByName(connectionName)
-    const connectionParams = this.extractConnectionParams(service, environment)
-    const dockerOptions = {enabled: true} as DockerOptions
-    const dbWrapper = this.dbWrapper(connectionParams, dockerOptions)
-
-    const dbConsoleCmd = dbWrapper.dbConsole(options)
-    this.cmdExec(dbConsoleCmd)
+  console(options: any, dataSourceName: string, environment: string) {
+    this.runDbCmd(dataSourceName, environment, 'console', options)
   }
 
-  create(connectionName: string, environment: string) {
-    this.validate(connectionName)
-    const service = this.connectionByName(connectionName)
-    const connectionParams = this.extractConnectionParams(service, environment)
-    const dockerOptions = {enabled: true} as DockerOptions
-    const dbWrapper = this.dbWrapper(connectionParams, dockerOptions)
-
-    const dbConsoleCmd = dbWrapper.dbCreate()
-    this.cmdExec(dbConsoleCmd)
+  create(dataSourceName: string, environment: string) {
+    this.runDbCmd(dataSourceName, environment, 'create', null)
   }
 
-  drop(connectionName: string, environment: string) {
-    this.validate(connectionName)
-    const service = this.connectionByName(connectionName)
-    const connectionParams = this.extractConnectionParams(service, environment)
-    const dockerOptions = {enabled: true} as DockerOptions
-    const dbWrapper = this.dbWrapper(connectionParams, dockerOptions)
-
-    const dbConsoleCmd = dbWrapper.dbDrop()
-    this.cmdExec(dbConsoleCmd)
+  drop(dataSourceName: string, environment: string) {
+    this.runDbCmd(dataSourceName, environment, 'drop', null)
   }
 
-  dump(options: PgdumpOptions, connectionName: string, environment: string) {
-    this.validate(connectionName)
-    const service = this.connectionByName(connectionName)
-    const connectionParams = this.extractConnectionParams(service, environment)
-    const dockerOptions = {enabled: true} as DockerOptions
-    const dbWrapper = this.dbWrapper(connectionParams, dockerOptions)
-
-    const dbDumpCmd = dbWrapper.dbDump(options)
-    this.cmdExec(dbDumpCmd)
+  dump(options: PgdumpOptions, dataSourceName: string, environment: string) {
+    this.runDbCmd(dataSourceName, environment, 'dump', options)
   }
 
-  restore(options: PgRestoreOptions, connectionName: string, environment: string) {
-    this.validate(connectionName)
-    const service = this.connectionByName(connectionName)
-    const connectionParams = this.extractConnectionParams(service, environment)
-    const dockerOptions = {enabled: true} as DockerOptions
-    const dbWrapper = this.dbWrapper(connectionParams, dockerOptions)
-
-    const dbRestoreCmd = dbWrapper.dbRestore(options)
-    this.cmdExec(dbRestoreCmd)
+  restore(options: PgRestoreOptions, dataSourceName: string, environment: string) {
+    this.runDbCmd(dataSourceName, environment, 'restore', options)
   }
 
-  private connectionByName(name: string) {
-    return this.connections.find((c: Connection) => c.name === name) as Connection
+  private dataSourceByName(name: string) {
+    return this.dataSources.find((c: DataSource) => c.name === name) as DataSource
   }
 
-  private connectionNames(): string[] {
-    return this.connections.map(s => s.name)
+  private dataSourceNames(): string[] {
+    return this.dataSources.map(s => s.name)
   }
 
-  private validate(connectionName: string) {
-    if (isEmpty(connectionName)) {
-      throw new Error('Missing required connectionName')
+  private validate(dataSourceName: string) {
+    if (isEmpty(dataSourceName)) {
+      throw new Error('Missing required dataSourceName')
     }
 
-    if (!this.connectionNames().includes(connectionName)) {
-      throw new Error(`Expected service ${connectionName} to be one of: ${this.connectionNames()}`)
+    if (!this.dataSourceNames().includes(dataSourceName)) {
+      throw new Error(`Expected service ${dataSourceName} to be one of: ${this.dataSourceNames()}`)
     }
   }
 
-  private cmdExec(cmd: string) {
+  private runDbCmd(dataSourceName: string, environment: string, cmd: string, options: any) {
+    this.validate(dataSourceName)
+    const dataSource = this.dataSourceByName(dataSourceName)
+    const dataSourceParams = this.extractDataSourceParams(dataSource, environment)
+
+    let sshCmdTemplate = ''
+
+    if (this.sshConnectionRequired(dataSourceParams)) {
+      const sshConnectionParams = dataSourceParams.ssh!
+      const localHostIp = address()
+      const localPort = sshConnectionParams.localPort
+      const jumpHost = sshConnectionParams.jumpHost
+      const remoteHost = dataSourceParams.host
+      const remotePort = dataSourceParams.port
+
+      dataSourceParams.host = localHostIp
+      dataSourceParams.port = localPort
+
+      sshCmdTemplate = `ssh -l $USER ${jumpHost} -f -o ExitOnForwardFailure=yes -L ${localHostIp}:${localPort}:${remoteHost}:${remotePort} sleep 10; eval "@@"`
+
+      if (!isEmpty(dataSourceParams.ssh!.beforeShellCmd)) {
+        const beforeShellCmd = dataSourceParams.ssh!.beforeShellCmd
+        sshCmdTemplate = `${beforeShellCmd} && ${sshCmdTemplate}`
+      }
+    }
+
+    const connectionParams = this.extractConnectionParams(dataSourceParams)
+    const dockerOptions = {enabled: true} as DockerOptions
+    const dbWrapper = this.dbWrapper(connectionParams, dockerOptions)
+
+    let shellCmdToExec
+
+    switch (cmd) {
+    case 'console':
+      shellCmdToExec = dbWrapper.dbConsole(options)
+      break
+    case 'create':
+      this.raiseReadOnlyErrorIfNeeded(dataSourceParams, cmd)
+      shellCmdToExec = dbWrapper.dbCreate()
+      break
+    case 'drop':
+      this.raiseReadOnlyErrorIfNeeded(dataSourceParams, cmd)
+      shellCmdToExec = dbWrapper.dbDrop()
+      break
+    case 'dump':
+      shellCmdToExec = dbWrapper.dbDump(options)
+      break
+    case 'restore':
+      this.raiseReadOnlyErrorIfNeeded(dataSourceParams, cmd)
+      shellCmdToExec = dbWrapper.dbRestore(options)
+      break
+    default:
+      throw new Error(`Command "${cmd}" not support`)
+    }
+
+    shellCmdToExec = isEmpty(sshCmdTemplate) ? shellCmdToExec : sshCmdTemplate.replace('@@', shellCmdToExec)
+
+    this.runShellCmd(shellCmdToExec)
+  }
+
+  private runShellCmd(cmd: string) {
     this.shellWrapper.run(cmd)
+  }
+
+  private raiseReadOnlyErrorIfNeeded(dataSourceParams: DataSourceParams, cmd: string) {
+    // tslint:disable-next-line
+    if (dataSourceParams.readonly === undefined || dataSourceParams.readonly === null || dataSourceParams.readonly) {
+      throw new Error(`Command "${cmd}" is not supported in a readonly connection -- check your configuration`)
+    }
   }
 
   private dbWrapper(connectionParams: ConnectionParams, dockerOptions: DockerOptions): PostgreSql {
     return new PostgreSql(connectionParams, dockerOptions)
   }
 
-  private extractConnectionParams(connection: Connection, environment: string): ConnectionParams {
-    const connectionParams = connection.environments[environment]
-
-    if (isEmpty(connectionParams)) {
-      throw new Error(`Connection params for environment "${environment}" not set`)
-    }
-
-    const host = connectionParams.host as string
-    const port = connectionParams.port as number
-    const database = connectionParams.database as string
-    const user = connectionParams.user as string
-    const password = connectionParams.password as string
+  private extractConnectionParams(dataSourceParams: DataSourceParams): ConnectionParams {
+    let host = dataSourceParams.host as string
+    let port = dataSourceParams.port as number
+    const database = dataSourceParams.database as string
+    const user = dataSourceParams.user as string
+    const password = dataSourceParams.password as string
 
     return { host,
       port,
@@ -120,5 +146,19 @@ export default class DbToolsWrapper {
       password,
       database
     } as ConnectionParams
+  }
+
+  private extractDataSourceParams(dataSource: DataSource, environment: string): DataSourceParams {
+    const dataSourceParams = dataSource.environments[environment]
+
+    if (isEmpty(dataSourceParams)) {
+      throw new Error(`Connection params for environment "${environment}" not set`)
+    }
+
+    return dataSourceParams
+  }
+
+  private sshConnectionRequired(dataSourceParams: DataSourceParams) {
+    return !isEmpty(dataSourceParams.ssh)
   }
 }

--- a/src/wrapper/db-tools/index.ts
+++ b/src/wrapper/db-tools/index.ts
@@ -9,7 +9,7 @@ export default abstract class extends BaseCommand {
     const mainConfig = ConfigUtils.mainConfigLoadDefault()
 
     return new DbToolsWrapper(
-      mainConfig.dbTools.connections,
+      mainConfig.dbTools.dataSources,
       dryRun,
       new BashWrapper({...BashWrapper.defaultOptions(), dryRun})
     )

--- a/test/commands/db/console.test.ts
+++ b/test/commands/db/console.test.ts
@@ -7,7 +7,7 @@ describe('db:console', () => {
     .env(env)
     .stdout()
     .command(['db:console', '--service', 'api', '--dry-run'])
-    .it('invokes db:console with a known connection', ctx => {
+    .it('invokes docker cmd to open a console', ctx => {
       const expectedOutput = 'docker run --rm -it --net=host -e PGPASSWORD=kgalli_pw -v $PWD:/opt -w /opt postgres psql -h 127.0.0.1 -p 5436 -U kgalli_us -d kgalli_db'
 
       expect(ctx.stdout).to.contain(expectedOutput)

--- a/test/commands/db/create.test.ts
+++ b/test/commands/db/create.test.ts
@@ -7,9 +7,16 @@ describe('db:create', () => {
     .env(env)
     .stdout()
     .command(['db:create', '--service', 'api', '--dry-run'])
-    .it('invokes db:create with a known connection', ctx => {
+    .it('invokes docker cmd to create database', ctx => {
       const expectedOutput = 'docker run --rm -it --net=host -e PGPASSWORD=kgalli_pw -v $PWD:/opt -w /opt postgres psql -h 127.0.0.1 -p 5436 -U kgalli_us -d template1 -c "CREATE DATABASE kgalli_db WITH OWNER kgalli_us ENCODING \'UTF8\' LC_COLLATE = \'en_US.utf8\' LC_CTYPE = \'en_US.utf8\';"'
 
       expect(ctx.stdout).to.contain(expectedOutput)
     })
+
+  test
+    .env(env)
+    .stdout()
+    .command(['db:create', '--service', 'api', '--environment', 'production', '--dry-run'])
+    .catch(err => expect(err.message).to.match(/Command "create" is not supported in a readonly connection/))
+    .it('raises an error due to readonly data source')
 })

--- a/test/commands/db/drop.test.ts
+++ b/test/commands/db/drop.test.ts
@@ -7,9 +7,16 @@ describe('db:drop', () => {
     .env(env)
     .stdout()
     .command(['db:drop', '--service', 'api', '--dry-run'])
-    .it('invokes db:drop with a known connection', ctx => {
+    .it('invokes docker cmd to drop database', ctx => {
       const expectedOutput = 'docker run --rm -it --net=host -e PGPASSWORD=kgalli_pw -v $PWD:/opt -w /opt postgres psql -h 127.0.0.1 -p 5436 -U kgalli_us -d template1 -c "DROP DATABASE IF EXISTS kgalli_db;"'
 
       expect(ctx.stdout).to.contain(expectedOutput)
     })
+
+  test
+    .env(env)
+    .stdout()
+    .command(['db:drop', '--service', 'api', '--environment', 'production', '--dry-run'])
+    .catch(err => expect(err.message).to.match(/Command "drop" is not supported in a readonly connection/))
+    .it('raises an error due to readonly data source')
 })

--- a/test/commands/db/dump.test.ts
+++ b/test/commands/db/dump.test.ts
@@ -7,7 +7,7 @@ describe('db:dump', () => {
     .env(env)
     .stdout()
     .command(['db:dump', '--service', 'api', '-t', 'kgalli-development.dump', '--dry-run'])
-    .it('invokes db:dump with a known connection', ctx => {
+    .it('invokes docker cmd to dump database', ctx => {
       const expectedOutput = 'docker run --rm -it --net=host -e PGPASSWORD=kgalli_pw -v $PWD:/opt -w /opt postgres pg_dump -h 127.0.0.1 -p 5436 -U kgalli_us --verbose --no-security-labels --no-owner --if-exists --clean --no-tablespaces --no-privileges --format=custom --file kgalli-development.dump -d kgalli_db'
 
       expect(ctx.stdout).to.contain(expectedOutput)

--- a/test/commands/db/restore.test.ts
+++ b/test/commands/db/restore.test.ts
@@ -7,9 +7,16 @@ describe('db:restore', () => {
     .env(env)
     .stdout()
     .command(['db:restore', '--service', 'api', '-r', 'kgalli-development.dump', '--dry-run'])
-    .it('invokes db:restore with a known connection', ctx => {
+    .it('invokes docker command to restore database', ctx => {
       const expectedOutput = 'docker run --rm -it --net=host -e PGPASSWORD=kgalli_pw -v $PWD:/opt -w /opt postgres pg_restore -h 127.0.0.1 -p 5436 -U kgalli_us --verbose --no-owner --no-privileges --format=custom -d kgalli_db kgalli-development.dump'
 
       expect(ctx.stdout).to.contain(expectedOutput)
     })
+
+  test
+    .env(env)
+    .stdout()
+    .command(['db:restore', '--service', 'api', '--environment', 'production', '-r', 'kgalli-development.dump', '--dry-run'])
+    .catch(err => expect(err.message).to.match(/Command "restore" is not supported in a readonly connection/))
+    .it('raises an error due to readonly data source')
 })

--- a/test/config/test-main-config.json
+++ b/test/config/test-main-config.json
@@ -95,7 +95,7 @@
       "test"
     ],
     "defaultEnvironment": "development",
-    "connections": [
+    "dataSources": [
       {
         "name": "api",
         "environments": {
@@ -106,12 +106,7 @@
             "password": "kgalli_pw",
             "database": "kgalli_db",
             "engine": "postgresql",
-            "ssh": {
-              "proxyHost": "",
-              "proxyUser": "",
-              "sshKeyLocation": "",
-              "sshKeyPassword": ""
-            }
+            "readonly": false
           }
         }
       }

--- a/test/config/test-main-config.json
+++ b/test/config/test-main-config.json
@@ -92,7 +92,7 @@
   "dbTools": {
     "environments": [
       "development",
-      "test"
+      "production"
     ],
     "defaultEnvironment": "development",
     "dataSources": [
@@ -107,6 +107,15 @@
             "database": "kgalli_db",
             "engine": "postgresql",
             "readonly": false
+          },
+          "production": {
+            "host": "127.0.0.1",
+            "port": "5436",
+            "user": "kgalli_us",
+            "password": "kgalli_pw",
+            "database": "kgalli_db",
+            "engine": "postgresql",
+            "readonly": true
           }
         }
       }


### PR DESCRIPTION
This PR allows defining SSH properties to be able to connect via SSH using a jump host. The implementation itself is relying on SSH already being installed on the machine as it does a simple wrapping of the actual db command into an SSH tunnel command.

```typescript
 if (this.sshConnectionRequired(dataSourceParams)) {
      const sshConnectionParams = dataSourceParams.ssh!
      const localHostIp = address()
      const localPort = sshConnectionParams.localPort
      const jumpHost = sshConnectionParams.jumpHost
      const remoteHost = dataSourceParams.host
      const remotePort = dataSourceParams.port

      dataSourceParams.host = localHostIp
      dataSourceParams.port = localPort

      sshCmdTemplate = `ssh -l $USER ${jumpHost} -f -o ExitOnForwardFailure=yes -L ${localHostIp}:${localPort}:${remoteHost}:${remotePort} sleep 10; eval "@@"`

      if (!isEmpty(dataSourceParams.ssh!.beforeShellCmd)) {
        const beforeShellCmd = dataSourceParams.ssh!.beforeShellCmd
        sshCmdTemplate = `${beforeShellCmd} && ${sshCmdTemplate}`
      }
    }
```

This PR also introduces the `readonly` flag for data sources. By flagging a data source with readonle destructive commands like `drop` (the database) will error out with an error message. 